### PR TITLE
mypy: depend on python3-types-requests

### DIFF
--- a/vcs-diff-lint.spec
+++ b/vcs-diff-lint.spec
@@ -15,6 +15,7 @@ Requires: csdiff
 Requires: git
 Requires: pylint
 Requires: python3-mypy
+Requires: python3-types-requests
 
 %description
 Analyze code, and print only reports related to a particular change.


### PR DESCRIPTION
Otherwise we errors like:
resalloc_ibm_cloud/ibm_cloud_vm.py:13: error: Library stubs not installed for "requests" (or incompatible with Python 3.11) resalloc_ibm_cloud/ibm_cloud_vm.py:13: note: Hint: "python3 -m pip install types-requests" resalloc_ibm_cloud/ibm_cloud_vm.py:13: note: (or run "mypy --install-types" to install all missing stub packages) resalloc_ibm_cloud/ibm_cloud_vm.py:13: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports Found 1 error in 1 file (checked 1 source file)