### PR TITLE
Correctly honor file renames

### DIFF
--- a/vcs-diff-lint
+++ b/vcs-diff-lint
@@ -85,7 +85,7 @@ class _Linter:
         rules = []
         for pair in self.renames:
             old, new = self.modify_rename(pair[0], pair[1])
-            rule = "s|: \"{}\"|: \"{}\"|".format(old, new)
+            rule = "s|^{}:|{}:|".format(old, new)
             rules += ['-e', rule]
 
         return ['sed'] + rules


### PR DESCRIPTION
The previous sed rule couldn't work, at least with the current error file formats like:

    Error: PYLINT_WARNING:
    tests/test_cli.py:6: W4901[deprecated-module]: Deprecated module 'pipes'

I suppose the error format got changed when we started using the vcs-diff-lint-csdiff-* wrappers.  Anyway, now we simply replace the filename starting from the beginning of the line.