### PR TITLE
Check the new code in a side-directory

### DIFF
--- a/vcs-diff-lint
+++ b/vcs-diff-lint
@@ -287,12 +287,27 @@ class _Worker:  # pylint: disable=too-few-public-methods
 
         # prepare the old checkout
         old_gitroot = os.path.join(self.workdir, 'old_dir')
+        new_gitroot = os.path.join(self.workdir, 'new_dir')
         origin_from = self.gitroot
         check_call(['git', 'clone', '--quiet', origin_from, old_gitroot])
+        check_call(['git', 'clone', '--quiet', origin_from, new_gitroot])
         ret_cwd = os.getcwd()
         try:
             os.chdir(old_gitroot)
             check_call(['git', 'checkout', '-q', self.checkout])
+        finally:
+            os.chdir(ret_cwd)
+
+        try:
+            os.chdir(new_gitroot)
+            with Popen(["git", "-C", origin_from, "diff", "--cached"],
+                       stdout=PIPE) as diff:
+                check_call(["git", "apply", "--allow-empty", "--index", "-"],
+                      stdin=diff.stdout)
+            with Popen(["git", "-C", origin_from, "diff"],
+                       stdout=PIPE) as diff:
+                check_call(["git", "apply", "--allow-empty", "-"],
+                      stdin=diff.stdout)
         finally:
             os.chdir(ret_cwd)
 
@@ -336,7 +351,7 @@ class _Worker:  # pylint: disable=too-few-public-methods
                     break
 
         for linterClass in selected_linters:
-            linter_new = linterClass(self.gitroot)
+            linter_new = linterClass(new_gitroot)
             linter_old = linterClass(old_gitroot, renames)
             linter_new.lint(self.projectdir, new_files, logfd=new_report_fd)
             linter_old.lint(self.projectdir, old_files, logfd=old_report_fd)


### PR DESCRIPTION
This makes a better Ruff linter isolation; without this, Ruff traverses all the gitroot sub-directories, including separate worktrees, temporary files, etc.  Then, since potential issues in such files are not present in the "old code" (even before linted on a clean checkout), vcs-diff-lint would report such irrelevant errors as "new" issues.

After this commit, both the old and new code is analyzed in a clean separate temporary directory.

Complements: 38412fb334387dfe8ca3857f7d6c12fe7e3f81d3