### PR TITLE
Don't require all the linters, just recommend them

### DIFF
--- a/vcs-diff-lint.spec
+++ b/vcs-diff-lint.spec
@@ -13,10 +13,10 @@ Source0: %name-%version.tar.gz
 
 Requires: csdiff
 Requires: git
-Requires: pylint
-Requires: python3-mypy
-Requires: python3-types-requests
-Requires: ruff
+Recommends: pylint
+Recommends: python3-mypy
+Recommends: python3-types-requests
+Recommends: ruff
 
 %description
 Analyze code, and print only reports related to a particular change.


### PR DESCRIPTION
I personally do not prefer installing some of those everywhere, yet I want to have vcs-diff-lint handy.

Relates: #27